### PR TITLE
Corrigido erro na interface Swagger

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -135,7 +135,7 @@
         }
       }
     },
-    "/messages/:id/parrot": {
+    "/messages/{messageId}/parrot": {
       "put": {
         "tags": [
           "message",
@@ -164,7 +164,7 @@
         }
       }
     },
-    "/messages/:id/unparrot": {
+    "/messages/{messageId}/unparrot": {
       "put": {
         "tags": [
           "message",


### PR DESCRIPTION
O erro foi descrito em #2 e consistia apenas no formato errado do parâmetro da URL